### PR TITLE
Improve speed of computation of `lmer` degrees of freedom

### DIFF
--- a/R/konfound-lmer.R
+++ b/R/konfound-lmer.R
@@ -10,8 +10,13 @@
 get_kr_df <- function(model_object) {
     L <- diag(rep(1, length(lme4::fixef(model_object))))
     L <- as.data.frame(L)
-    out <- suppressWarnings(purrr::map_dbl(L, pbkrtest::get_Lb_ddf, 
-                                           object = model_object))
+    vcov_adj <- pbkrtest::vcovAdj(model_object)
+    vcov_0 <- vcov(model_object)
+    out <- suppressWarnings(purrr::map_dbl(
+      L,
+      pbkrtest::Lb_ddf,
+      V0 = vcov_0, Vadj = vcov_adj
+    ))
     names(out) <- names(lme4::fixef(model_object))
     out
 }


### PR DESCRIPTION
- `pbkrtest::get_Lb_ddf` is just a wrapper around `pbkrtest::Lb_ddf`: https://github.com/hojsgaard/pbkrtest/blob/7036de46aaec0f21b2079b77abee4d74095b5bc3/pbkrtest_devel/pbkrtest-gls/R/get_ddf_Lb.R#L52-L54 
- computation of `V0` and `Vadj` is expensive but is now pre-computed only once